### PR TITLE
Improve Redis client resilience and split K8s health probes

### DIFF
--- a/k8s/base/api-deployment.yaml
+++ b/k8s/base/api-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: /api/health/live
               port: 7600
             initialDelaySeconds: 15
             periodSeconds: 10

--- a/src/backend/src/api.ts
+++ b/src/backend/src/api.ts
@@ -15,6 +15,7 @@ router.use("/auth", createAuthRateLimiter(), authRouter);
 router.use("/user", userRouter);
 
 router.get("/health", HealthController.getHealth);
+router.get("/health/live", HealthController.getLive);
 
 router.get("/metrics", MetricsController.getMetrics);
 

--- a/src/backend/src/controllers/health.controllers.ts
+++ b/src/backend/src/controllers/health.controllers.ts
@@ -3,9 +3,21 @@ import redisClient from "@/lib/redis.client";
 import Logger from "@/lib/logger";
 
 export default class HealthController {
+  /**
+   * Liveness probe: checks only that the HTTP server is running.
+   * K8s uses this to decide whether to restart the pod - Redis being
+   * temporarily down is not a reason to restart.
+   */
+  static getLive(_req: Request, res: Response) {
+    res.status(200).json({ status: "alive" });
+  }
+
+  /**
+   * Readiness probe: checks Redis connectivity.
+   * K8s uses this to decide whether to route traffic to the pod.
+   */
   static async getHealth(_req: Request, res: Response) {
     try {
-      // Check database/Redis connectivity
       await redisClient.ping();
 
       res.status(200).json({

--- a/src/backend/src/lib/redis.client.ts
+++ b/src/backend/src/lib/redis.client.ts
@@ -4,14 +4,22 @@ import Logger from "@/lib/logger";
 
 const client = createClient({
   url: config.redis.url,
+  // Forces a CLIENT SETNAME command during the connection handshake. Without
+  // this, when no auth/SELECT/RESP3 is configured the handshake is empty and
+  // the client marks the connection as "ready" the instant TCP connects -
+  // even if the remote end isn't a real Redis (e.g. Docker Desktop proxy
+  // keeping the port open after container stop on Windows). With a non-empty
+  // handshake the client waits for a Redis response before emitting "ready".
+  name: "tunele-api",
   socket: {
-    // Disable automatic reconnection
-    reconnectStrategy: false,
-    // Set connection timeout
+    reconnectStrategy: (retries: number) => {
+      return Math.min(2 ** retries * 500, 10000);
+    },
     connectTimeout: 5000,
-    // Set socket timeout
-    timeout: 5000,
+    socketTimeout: 5000,
   },
+  pingInterval: 5000,
+  disableOfflineQueue: true,
 });
 
 client.on("error", (error) => {

--- a/src/backend/src/lib/redis.service.ts
+++ b/src/backend/src/lib/redis.service.ts
@@ -75,10 +75,8 @@ export class RedisService {
 
     try {
       await client.quit();
-      redisMetrics.setConnectionStatus(false);
       Logger.info("Redis disconnected successfully");
     } catch (error) {
-      redisMetrics.setConnectionStatus(false);
       Logger.error("Failed to disconnect from Redis", { error });
     }
   }

--- a/src/backend/src/lib/redis.service.ts
+++ b/src/backend/src/lib/redis.service.ts
@@ -39,25 +39,25 @@ async function withMetrics<T>(
 }
 
 export class RedisService {
-  private static isConnected = false;
+  static {
+    client.on("ready", () => redisMetrics.setConnectionStatus(true));
+    client.on("end", () => redisMetrics.setConnectionStatus(false));
+    client.on("reconnecting", () => redisMetrics.setConnectionStatus(false));
+  }
 
   /**
    * Connect to Redis.
    */
   static async connect(): Promise<void> {
-    if (this.isRedisConnected()) {
+    if (client.isOpen) {
       Logger.warn("Redis is already connected");
       return;
     }
 
     try {
       await client.connect();
-      this.isConnected = true;
-      redisMetrics.setConnectionStatus(true);
       Logger.info("Redis connected successfully");
     } catch (error) {
-      this.isConnected = false;
-      redisMetrics.setConnectionStatus(false);
       Logger.error("Failed to connect to Redis", { error });
       if (config.env === "production") throw new InternalServerErrorException();
       throw new HttpException(500, "Failed to connect to Redis");
@@ -68,28 +68,26 @@ export class RedisService {
    * Disconnect from Redis.
    */
   static async disconnect(): Promise<void> {
-    if (!this.isRedisConnected()) {
+    if (!client.isOpen) {
       Logger.warn("Redis is already disconnected");
       return;
     }
 
     try {
       await client.quit();
-      this.isConnected = false;
       redisMetrics.setConnectionStatus(false);
       Logger.info("Redis disconnected successfully");
     } catch (error) {
-      this.isConnected = false;
       redisMetrics.setConnectionStatus(false);
       Logger.error("Failed to disconnect from Redis", { error });
     }
   }
 
   /**
-   * Check if Redis is connected
+   * Check if Redis is connected and ready to accept commands.
    */
   static isRedisConnected(): boolean {
-    return this.isConnected;
+    return client.isReady;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR hardens the Redis client and aligns the Kubernetes health probe configuration with how K8s is designed to work.

### Separate liveness and readiness probes
Added a dedicated `/api/health/live` endpoint that returns `200 { status: "alive" }` as long as the HTTP server is running. The existing `/api/health` (which checks Redis connectivity via `ping`) stays as the readiness probe. The K8s deployment's liveness probe now points to `/api/health/live`, so a Redis outage no longer triggers pod restarts — it only stops traffic routing until Redis recovers.

### Exponential backoff reconnection
Replaced `reconnectStrategy: false` (no reconnects at all) with exponential backoff capped at 10 seconds (`Math.min(2^retries * 500, 10_000)`). The client now automatically recovers from Redis restarts or transient network issues.

### Reliable connection handshake
Added `name: "tunele-api"` to the client config, which forces a `CLIENT SETNAME` command during the connection handshake. Without it, when no auth/SELECT/RESP3 is configured the handshake is empty and the client marks the connection as "ready" the instant TCP connects — even if the remote end isn't a real Redis server (e.g. Docker Desktop keeping the port open after a container stop on Windows).

### Event-driven connection metrics
Replaced the manual `isConnected` boolean with Redis client event listeners (`ready`, `end`, `reconnecting`) to drive `redisMetrics.setConnectionStatus()`. Connection state is now tracked by the client itself (`client.isReady` / `client.isOpen`) rather than managed manually, which is more accurate.

## Test plan
- [x] CI passes
- [x] `/api/health/live` returns `200` when the server is running but Redis is down
- [x] `/api/health` returns unhealthy when Redis is down (readiness probe still gates traffic)
- [x] Redis reconnects automatically after a restart (exponential backoff visible in logs)